### PR TITLE
Seasonal Malaria Chemoprevention Implementation

### DIFF
--- a/src/Core/Config/Config.cpp
+++ b/src/Core/Config/Config.cpp
@@ -45,7 +45,19 @@ void Config::read_from_file(const std::string &config_file_name) {
 
   try {
     for (auto &config_item : config_items) {
-      LOG(INFO) << "Reading config item: " << config_item->name();
+      //LOG(INFO) << "Reading config item: " << config_item->name();
+
+
+      // Debug for SMC parsing
+      // const std::string key = config_item->name();
+
+      // if (config[key]) {
+      //   LOG(INFO) << "  --> Raw value from YAML: " << YAML::Dump(config[key]);
+      // } else {
+      //   LOG(WARNING) << "  --> Key not found in YAML!";
+      // }
+
+
       config_item->set_value(config);
     }
   } catch (std::invalid_argument &error) {

--- a/src/Core/Config/Config.h
+++ b/src/Core/Config/Config.h
@@ -108,6 +108,20 @@ public:
 
   CONFIG_ITEM(mda_therapy_id, int, 0)
 
+    // added for SMC July 2025
+  CONFIG_ITEM(smc_therapy_id, int, 0)
+  CONFIG_ITEM(smc_districts, IntVector, IntVector())
+  CONFIG_ITEM(mean_prob_individual_present_at_smc, DoubleVector, DoubleVector())
+  CONFIG_ITEM(sd_prob_individual_present_at_smc, DoubleVector, DoubleVector())
+  CONFIG_ITEM(smc_reporting_start_day, date::year_month_day, date::year_month_day{date::year{2011} / 1 / 1})
+  CONFIG_ITEM(smc_reporting_end_day, date::year_month_day, date::year_month_day{date::year{2011} / 1 / 1})
+  //CONFIG_ITEM(smc_reporting_interval, int, 1) // implement if required
+  CONFIG_ITEM(smc_reporting_number_of_people_tracked, int, 100)
+  CONFIG_ITEM(smc_reporting_track_per_district, bool, false)
+  CONFIG_ITEM(smc_refresh_samples_each_interval, bool, false)
+  CONFIG_ITEM(has_effective_drug_in_blood_threshold, double, 0.5)
+  CONFIG_ITEM(coverage_adjustment, bool, true)
+
   CONFIG_ITEM(artificial_rescaling_of_population_size, double, 1.0)
 
   CONFIG_ITEM(cell_level_reporting, bool, false)
@@ -153,6 +167,10 @@ public:
   CUSTOM_CONFIG_ITEM(prob_individual_present_at_mda_distribution,
                      std::vector<beta_distribution_params>())
 
+  //added for SMC
+  CUSTOM_CONFIG_ITEM(prob_individual_present_at_smc_distribution,
+                     std::vector<beta_distribution_params>())
+
   CUSTOM_CONFIG_ITEM(rapt_config, RaptConfigEntry())
   VIRTUAL_PROPERTY_REF(double, modified_mutation_factor)
 
@@ -171,6 +189,9 @@ public:
   // added for ASTC May 2025
   CONFIG_ITEM(treatment_age_classes_upper, std::vector<int>, (std::vector<int>{5, 100}))
   CONFIG_ITEM(treatment_adjustments, std::vector<double>, (std::vector<double>{1, 1}))
+
+
+  
 
 };
 

--- a/src/Core/Config/ConfigItem.hxx
+++ b/src/Core/Config/ConfigItem.hxx
@@ -70,6 +70,9 @@ void ConfigItem<T>::set_value(const YAML::Node &node) {
   // Store the value if there is one
   if (node[name_]) {
     value_ = node[name_].template as<T>();
+
+    //LOG(INFO) << "Setting value for " << name_ << ", parsed value: " << value_;
+
     return;
   }
 

--- a/src/Core/Config/CustomConfigItem.cpp
+++ b/src/Core/Config/CustomConfigItem.cpp
@@ -532,3 +532,38 @@ void prob_individual_present_at_mda_distribution::set_value(
     value_.push_back(params);
   }
 }
+
+
+// added for SMC
+void prob_individual_present_at_smc_distribution::set_value(
+    const YAML::Node &node) {
+  value_.clear();
+
+  // get district not pixel
+  // auto number_of_locations = Model::CONFIG->number_of_locations();
+  // for (std::size_t loc = 0;
+  //      loc < number_of_locations; loc++) {
+
+
+  //     auto input_loc = config_->mean_prob_individual_present_at_smc().size()
+  //                              < number_of_locations
+  //                          ? 0
+  //                          : loc;
+  for (std::size_t i = 0;
+       i < config_->mean_prob_individual_present_at_smc().size(); i++) {
+    const auto mean = config_->mean_prob_individual_present_at_smc()[i];
+    const auto sd = config_->sd_prob_individual_present_at_smc()[i];
+
+    beta_distribution_params params{};
+
+    if (NumberHelpers::is_zero(sd)) {
+      params.alpha = mean;
+      params.beta = 0.0;
+    } else {
+      params.alpha = mean * mean * (1 - mean) / (sd * sd) - mean;
+      params.beta = params.alpha / mean - params.alpha;
+    }
+
+    value_.push_back(params);
+  }
+}

--- a/src/Core/Config/CustomConfigItem.h
+++ b/src/Core/Config/CustomConfigItem.h
@@ -384,4 +384,29 @@ public:
   void set_value(const YAML::Node &node) override;
 };
 
+// added for SMC
+class prob_individual_present_at_smc_distribution : public IConfigItem {
+  DELETE_COPY_AND_MOVE(prob_individual_present_at_smc_distribution)
+
+public:
+  std::vector<beta_distribution_params> value_;
+
+public:
+  // constructor
+  explicit prob_individual_present_at_smc_distribution(
+      const std::string &name,
+      std::vector<beta_distribution_params> default_value,
+      Config* config = nullptr)
+      : IConfigItem(config, name), value_{std::move(default_value)} {}
+
+  // destructor
+  virtual ~prob_individual_present_at_smc_distribution() = default;
+
+  // accessor to the underlying vector of beta_distribution_params
+  virtual std::vector<beta_distribution_params>& operator()() { return value_; }
+
+  // load from YAML node override
+  void set_value(const YAML::Node &node) override;
+};
+
 #endif

--- a/src/Events/Population/PopulationEventBuilder.cpp
+++ b/src/Events/Population/PopulationEventBuilder.cpp
@@ -30,6 +30,7 @@
 #include "ModifyNestedMFTEvent.h"
 #include "RotateStrategyEvent.h"
 #include "SingleRoundMDAEvent.h"
+#include "SMCEvent.h"
 #include "TurnOffMutationEvent.h"
 #include "TurnOnMutationEvent.h"
 #include "UpdateBetaRasterEvent.hxx"
@@ -218,6 +219,101 @@ std::vector<Event*> PopulationEventBuilder::build_single_round_mda_event(
 
   return events;
 }
+
+// added for SMC (no scaling of coverage, same coverage for all years)
+// std::vector<Event*> PopulationEventBuilder::build_smc_event(
+//     const YAML::Node &node, Config* config) {
+//   std::vector<Event*> events;
+
+//   for (const auto &entry : node) {
+//     auto districts = entry["districts"].as<std::vector<int>>();
+//     auto year_range = entry["year_range"].as<std::vector<int>>();
+//     auto months = entry["months"].as<std::vector<int>>();
+//     auto age_range = entry["age_range"].as<std::vector<int>>();
+//     auto fraction_population_targeted = entry["fraction_population_targeted"].as<std::vector<double>>();
+//     auto days_to_complete_all_treatments = entry["days_to_complete_all_treatments"].as<int>();
+//     int start_year = year_range.front();
+//     int end_year = (year_range.size() > 1) ? year_range.back() : start_year;
+
+//     for (int year = start_year; year <= end_year; ++year) {
+//       for (const int month : months) {
+//         date::year_month_day starting_date = date::year{year} / month / 25;
+//         auto time = (date::sys_days{starting_date} - date::sys_days{config->starting_date()}).count();
+
+//         auto* e = new SMCEvent(time);
+//         e->smc_year = year;
+//         e->smc_month = month;
+//         e->districts = districts;
+//         e->fraction_population_targeted = fraction_population_targeted;
+//         e->age_range = age_range;
+//         e->days_to_complete_all_treatments = days_to_complete_all_treatments;
+
+//         events.push_back(e);
+//       }
+//     }
+//   }
+
+//   return events;
+// }
+
+// added for SMC (scaling of SMC coverage to impart lower coverage to earlier years)
+std::vector<Event*> PopulationEventBuilder::build_smc_event(
+    const YAML::Node &node, Config* config) {
+  std::vector<Event*> events;
+
+  for (const auto &entry : node) {
+    auto districts = entry["districts"].as<std::vector<int>>();
+    auto year_range = entry["year_range"].as<std::vector<int>>();
+    auto months = entry["months"].as<std::vector<int>>();
+    auto age_range = entry["age_range"].as<std::vector<int>>();
+    auto base_fraction_population_targeted =
+        entry["fraction_population_targeted"].as<std::vector<double>>();
+    auto days_to_complete_all_treatments =
+        entry["days_to_complete_all_treatments"].as<int>();
+
+    int start_year = year_range.front();
+    int end_year = (year_range.size() > 1) ? year_range.back() : start_year;
+
+    for (int year = start_year; year <= end_year; ++year) {
+      // Coverage is defined for year 2024.
+      // Each year before 2024 is reduced by 10% of the 2024 value,
+      // with a minimum of 10% of the 2024 coverage.
+      // 2024 and later remain at the 2024 level.
+      double scale_factor = 1.0;
+      if (Model::CONFIG->coverage_adjustment()){
+      if (year < 2024) {
+        scale_factor = 1.0 - 0.1 * (2024 - year);
+        if (scale_factor < 0.1) scale_factor = 0.1;
+      }
+      }
+
+      std::vector<double> scaled_fraction_population_targeted =
+          base_fraction_population_targeted;
+      for (auto& coverage : scaled_fraction_population_targeted) {
+        coverage *= scale_factor;
+      }
+
+      for (const int month : months) {
+        date::year_month_day starting_date = date::year{year} / month / 25;
+        auto time =
+            (date::sys_days{starting_date} - date::sys_days{config->starting_date()}).count();
+
+        auto* e = new SMCEvent(time);
+        e->smc_year = year;
+        e->smc_month = month;
+        e->districts = districts;
+        e->fraction_population_targeted = scaled_fraction_population_targeted;
+        e->age_range = age_range;
+        e->days_to_complete_all_treatments = days_to_complete_all_treatments;
+
+        events.push_back(e);
+      }
+    }
+  }
+
+  return events;
+}
+
 
 std::vector<Event*>
 PopulationEventBuilder::build_modify_nested_mft_strategy_event(
@@ -618,6 +714,11 @@ std::vector<Event*> PopulationEventBuilder::build(const YAML::Node &node,
 
   if (name == "single_round_MDA") {
     events = build_single_round_mda_event(node["info"], config);
+  }
+
+  //added for SMC July 2025
+  if (name == "SMC") {
+    events = build_smc_event(node["info"], config);
   }
 
   if (name == "modify_nested_mft_strategy") {

--- a/src/Events/Population/PopulationEventBuilder.h
+++ b/src/Events/Population/PopulationEventBuilder.h
@@ -41,6 +41,10 @@ public:
 
   static std::vector<Event*> build_single_round_mda_event(
       const YAML::Node &node, Config* config);
+  
+  //added for SMC
+  static std::vector<Event*> build_smc_event(
+      const YAML::Node &node, Config* config); 
 
   static std::vector<Event*> build_modify_nested_mft_strategy_event(
       const YAML::Node &node, Config* config);

--- a/src/Events/Population/SMCEvent.cpp
+++ b/src/Events/Population/SMCEvent.cpp
@@ -1,0 +1,216 @@
+#include "SMCEvent.h"
+#include "Core/Config/Config.h"
+#include "Core/Random.h"
+#include "Events/ReceiveSMCTherapyEvent.h" 
+#include "Model.h"
+#include "Population/Population.h"
+#include "Population/Properties/PersonIndexByLocationStateAgeClass.h"
+#include "Population/Properties/PersonIndexAll.h"
+#include "date/date.h"
+#include "easylogging++.h"
+#include <unordered_set>
+
+SMCEvent::SMCEvent(const int &execute_at) {
+  time = execute_at;
+}
+
+void SMCEvent::execute() {
+  LOG(INFO) << date::year_month_day{scheduler->calendar_date}
+            << ": executing SMCEvent";
+
+  // const auto& tracked_ids = Model::POPULATION->smc_tracked_person_ids();
+  // std::unordered_set<int> eligible_set;
+
+  for(auto &district : districts){
+    if (district < 1 || district > SpatialData::get_instance().get_boundary("district")->max_unit_id) {
+      LOG(ERROR) << "District ID " << district << " is out of valid range [1, "
+                 << SpatialData::get_instance().get_boundary("district")->max_unit_id << "]";
+      return;
+    }
+
+    auto locations = SpatialData::get_instance().get_locations_in_unit("district", district);
+    auto it = std::find(districts.begin(), districts.end(), district);
+    
+    // Find the corresponding index in districts
+    std::size_t district_index = std::distance(districts.begin(), it);
+    double fraction = fraction_population_targeted[district_index];
+
+    auto pi_lsa = Model::POPULATION->get_person_index<PersonIndexByLocationStateAgeClass>();
+
+    std::vector<Person*> eligible_persons;
+
+    for (auto hs = 0; hs < Person::DEAD; hs++) {
+      for (std::size_t ac = 0; ac < Model::CONFIG->number_of_age_classes(); ac++) {
+        for (auto loc : locations) {
+          for (auto* p : pi_lsa->vPerson()[loc][hs][ac]) {
+
+            double age_in_years = p->age_in_floating();
+            double min_age_years = age_range[0] / 12.0;
+            double max_age_years = age_range[1] / 12.0;
+
+            if (age_in_years >= min_age_years && age_in_years < max_age_years) {
+                 eligible_persons.push_back(p);
+            }
+          
+          }
+        }
+      }
+    }
+
+    const std::size_t total_eligible = eligible_persons.size();
+    unsigned int num_targeted = Model::RANDOM->random_poisson(fraction * total_eligible);
+
+    if (fraction >= 1.0) {
+      num_targeted = total_eligible;
+    } 
+    else {
+      num_targeted = Model::RANDOM->random_poisson(fraction * total_eligible);
+      if (num_targeted > total_eligible) {
+        num_targeted = total_eligible;
+      }
+    }
+
+
+    // std::cout << "Location (District): " << district
+    //           << ", Fraction targeted: " << fraction
+    //           << ", Total eligible individuals: " << total_eligible
+    //           << ", Number targeted for SMC final: " << num_targeted << std::endl;
+
+
+
+    //int schedule_count = 0;
+    if (!eligible_persons.empty()) {
+      Model::RANDOM->shuffle(&eligible_persons[0], eligible_persons.size(), sizeof(std::size_t));
+    }
+
+    // for (auto* p : eligible_persons) {
+    //   eligible_set.insert(p->get_uid());
+    // }
+
+
+    for (std::size_t p_i = 0; p_i < num_targeted; ++p_i) {
+      auto* person = eligible_persons[p_i];
+
+      const auto prob = Model::RANDOM->random_flat(0.0, 1.0);
+      if (prob <= person->prob_present_at_smc()) {
+        auto* therapy = Model::CONFIG->therapy_db()[Model::CONFIG->smc_therapy_id()];
+
+        int days_to_receive_smc = Model::RANDOM->random_uniform(days_to_complete_all_treatments) + 1;
+        int scheduled_time = Model::SCHEDULER->current_time() + days_to_receive_smc;
+
+
+        ReceiveSMCTherapyEvent::schedule_event(Model::SCHEDULER, person, therapy, scheduled_time);
+        //schedule_count++;
+      }
+    }
+    // std::cout << "Number of individuals who received SMC in District " << district
+    //           << ": " << schedule_count << std::endl;
+
+
+
+
+
+
+  }
+
+  // Uncomment for debugging missing tracked children
+
+  /*
+
+  
+
+  // Check for missing tracked children
+  std::vector<int> missing_tracked;
+  std::vector<int> eligible_tracked;
+  
+  for (int uid : tracked_ids) {
+    if (eligible_set.count(uid) == 0) {
+        // tracked child is NOT eligible this round
+        missing_tracked.push_back(uid);
+    } else {
+        eligible_tracked.push_back(uid);
+    }
+  }
+
+    auto* all_person_index = Model::POPULATION->get_person_index<PersonIndexAll>();
+
+    std::vector<Person*> tracked_missing_persons;
+    std::vector<int> not_found_uids;
+
+    for (int uid : missing_tracked) {
+
+        bool found = false;
+
+        // Search for the person in the index
+        for (auto* person : all_person_index->vPerson()) {
+            if (person->get_uid() == uid) {
+                tracked_missing_persons.push_back(person);
+                found = true;
+                break;
+            }
+        }
+
+        // If not found, record UID
+        if (!found) {
+            not_found_uids.push_back(uid);
+        }
+    }
+
+  if (!not_found_uids.empty()) {
+      std::cout << "Warning: The following tracked UIDs were not found in the population:\n";
+      for (int uid : not_found_uids) {
+          std::cout << "  UID " << uid << "\n";
+      }
+  }
+
+
+  // Debug output
+  std::cout << eligible_tracked.size() << " tracked children eligible "
+          << "and " << missing_tracked.size() << " tracked children NOT eligible."
+          << std::endl;
+
+  if (!missing_tracked.empty()) {
+    std::cout << "Detailed info for tracked children NOT eligible:\n";
+
+    for (Person* p : tracked_missing_persons) {
+
+
+        double age = p->age_in_floating();
+        int loc = p->location();
+        int hs  = p->host_state();
+
+        // derive district for info
+        int p_district = SpatialData::get_instance()
+                             .get_admin_unit("district", loc);
+
+        double min_age_years = age_range[0] / 12.0;
+        double max_age_years = age_range[1] / 12.0;
+
+        bool wrong_age = !(age >= min_age_years && age <= max_age_years);
+        bool dead = (hs == Person::DEAD);
+
+        std::cout << "  UID " << p->get_uid()
+                  << " | Age=" << age
+                  << " | Location=" << loc
+                  << " | District=" << p_district
+                  << " | HealthState=" << hs;
+
+        if (wrong_age) {
+            std::cout << " | REASON: age not in [" 
+                      << min_age_years << ", " << max_age_years << "]";
+        }
+
+        if (dead) {
+            std::cout << " | REASON: DEAD";
+        }
+
+        std::cout << "\n";
+    }
+}
+
+*/
+
+
+  
+
+}

--- a/src/Events/Population/SMCEvent.h
+++ b/src/Events/Population/SMCEvent.h
@@ -1,0 +1,41 @@
+#ifndef SMCEVENT_H
+#define SMCEVENT_H
+
+#include <vector>
+
+#include "Core/PropertyMacro.h"
+#include "Events/Event.h"
+
+class SMCEvent : public Event {
+  DELETE_COPY_AND_MOVE(SMCEvent)
+
+public:
+  // Fraction of population targeted for each district listed
+  std::vector<double> fraction_population_targeted;
+
+  // Maximum number of days within which all treatments are given
+  int days_to_complete_all_treatments{14};
+
+  // List of targeted districts (location indices)
+  std::vector<int> districts;
+
+  // Age range for targeted population [min_age, max_age]
+  std::vector<int> age_range{0, 120};
+
+  // SMC year
+  int smc_year;
+
+  // SMC month
+  int smc_month;
+
+  explicit SMCEvent(const int &execute_at);
+
+  virtual ~SMCEvent() = default;
+
+  std::string name() override { return "SMCEvent"; }
+
+private:
+  void execute() override;
+};
+
+#endif  // SMCEVENT_H

--- a/src/Events/Population/SingleRoundMDAEvent.cpp
+++ b/src/Events/Population/SingleRoundMDAEvent.cpp
@@ -46,8 +46,20 @@ void SingleRoundMDAEvent::execute() {
             ? number_indidividuals_in_location
             : number_of_individuals_will_receive_mda;
     // shuffle app_persons_in_location index for sampling without replacement
+
+    
+
+    // std::cout<< "Number of individuals in location " << loc
+    //     << ": " << number_indidividuals_in_location
+    //     << ", Number of individuals will receive MDA: "
+    //     << number_of_individuals_will_receive_mda << std::endl;
+
+    //fix (check if empty)
+    if (!all_persons_in_location.empty()) {
     Model::RANDOM->shuffle(&all_persons_in_location[0],
                            all_persons_in_location.size(), sizeof(std::size_t));
+    }
+    
 
     for (std::size_t p_i = 0; p_i < number_of_individuals_will_receive_mda;
          p_i++) {

--- a/src/Events/ReceiveSMCTherapyEvent.cpp
+++ b/src/Events/ReceiveSMCTherapyEvent.cpp
@@ -1,0 +1,78 @@
+/*
+ * File:   ReceiveSMCTherapyEvent.cpp
+ * Author: Sarit
+ *
+ * Created on July 7, 2025
+ */
+
+#include "ReceiveSMCTherapyEvent.h"
+
+#include "Core/Scheduler.h"
+#include "Model.h"
+#include "Population/Person.h"
+#include "Therapies/Therapy.hxx"
+#include "Population/DrugsInBlood.h"
+#include "Therapies/Drug.h"
+
+ReceiveSMCTherapyEvent::ReceiveSMCTherapyEvent() : received_therapy_(nullptr) {}
+
+ReceiveSMCTherapyEvent::~ReceiveSMCTherapyEvent() = default;
+
+void ReceiveSMCTherapyEvent::schedule_event(Scheduler* scheduler, Person* p,
+                                            Therapy* therapy, const int &time) {
+                                      
+
+
+  if (scheduler != nullptr) {
+
+    // std::cout << "Scheduling ReceiveSMCTherapyEvent for person ID: "
+    //         << p->get_uid() << std::endl;
+
+
+
+    auto* e = new ReceiveSMCTherapyEvent();
+    e->dispatcher = p;
+    e->set_received_therapy(therapy);
+    e->time = time;
+
+    p->add(e);
+    scheduler->schedule_individual_event(e);
+  }
+}
+
+void ReceiveSMCTherapyEvent::execute() {
+  auto* person = dynamic_cast<Person*>(dispatcher);
+  // If needed, add eligibility checks (e.g., age checks for SMC) here
+
+  // std::cout << "Executing ReceiveSMCTherapyEvent for person ID: "
+  //           << person->get_uid() << std::endl;
+
+  
+
+  //std::cout << "person "<< person->get_uid() << " is receiving therapy "<< std::endl;
+  //received_therapy_->print(std::cout);
+  person->receive_therapy(received_therapy_, nullptr);
+
+  // for (const auto &kv_drug : *person->drugs_in_blood()->drugs()) {
+
+  //   std::cout <<"Person ID: "<< person->get_uid() <<" Drug ID: "<< kv_drug.first << " Last update value: " <<kv_drug.second->last_update_value() <<std::endl;
+
+
+  // }
+
+  //person->
+
+  // Cancel progress to clinical events if needed
+  person->cancel_all_other_progress_to_clinical_events_except(nullptr);
+  person->change_all_parasite_update_function(
+      Model::MODEL->progress_to_clinical_update_function(),
+      Model::MODEL->immunity_clearance_update_function());
+
+  person->schedule_update_by_drug_event(nullptr);
+
+
+ 
+  // for (const auto &kv_drug : *person->drugs_in_blood()->drugs()) {
+  //   std::cout <<"Person ID: "<< person->get_uid() <<" Drug ID: "<< kv_drug.first << " Last update value: " <<kv_drug.second->last_update_value() <<std::endl;
+  // }
+}

--- a/src/Events/ReceiveSMCTherapyEvent.h
+++ b/src/Events/ReceiveSMCTherapyEvent.h
@@ -1,0 +1,38 @@
+/*
+ * File:   ReceiveSMCTherapyEvent.h
+ * Author: Sarit
+ *
+ * Created on July 7, 2025
+ */
+
+#ifndef RECEIVESMCTHERAPYEVENT_H
+#define RECEIVESMCTHERAPYEVENT_H
+
+#include <string>
+
+#include "Core/PropertyMacro.h"
+#include "Event.h"
+
+class Scheduler;
+class Person;
+class Therapy;
+
+class ReceiveSMCTherapyEvent : public Event {
+  DELETE_COPY_AND_MOVE(ReceiveSMCTherapyEvent)
+
+  POINTER_PROPERTY(Therapy, received_therapy)
+
+public:
+  ReceiveSMCTherapyEvent();
+  virtual ~ReceiveSMCTherapyEvent();
+
+  static void schedule_event(Scheduler* scheduler, Person* p, Therapy* therapy,
+                             const int &time);
+
+  std::string name() override { return "ReceiveSMCTherapyEvent"; }
+
+private:
+  void execute() override;
+};
+
+#endif /* RECEIVESMCTHERAPYEVENT_H */

--- a/src/Events/ReceiveTherapyEvent.cpp
+++ b/src/Events/ReceiveTherapyEvent.cpp
@@ -39,6 +39,7 @@ void ReceiveTherapyEvent::schedule_event(
 
 void ReceiveTherapyEvent::execute() {
   auto* person = dynamic_cast<Person*>(dispatcher);
+  //std::cout<<person->get_uid()<<" is receiving therapy 2222 "<<std::endl;
   person->receive_therapy(received_therapy_, clinical_caused_parasite_,
                           is_mac_therapy_);
   person->schedule_update_by_drug_event(clinical_caused_parasite_);

--- a/src/GIS/SpatialData.h
+++ b/src/GIS/SpatialData.h
@@ -47,11 +47,11 @@ public:
     // Probability of treatment, over 5
     PrTreatmentOver5,
 
-    // Number of sequential items in the type
-    Count,
-
     // Base treatment level (added for ASTC May 2025)
-    PrTreatmentBase
+    PrTreatmentBase,
+
+    // Number of sequential items in the type
+    Count
   };
 
   struct RasterInformation {

--- a/src/Model.cpp
+++ b/src/Model.cpp
@@ -40,6 +40,8 @@
 #include "Treatment/SteadyTCM.hxx"
 #include "easylogging++.h"
 
+#include "Reporters/SMCReporter.h" //added for SMC
+
 Model* Model::MODEL = nullptr;
 Config* Model::CONFIG = nullptr;
 Random* Model::RANDOM = nullptr;
@@ -330,6 +332,31 @@ void Model::daily_update(const int &current_time) {
 
   // check to switch strategy
   treatment_strategy_->update_end_of_time_step();
+
+  // START added for SMC custom report
+
+  // Compute current date in sys_days
+  date::sys_days cur_sd = date::sys_days{ config_->starting_date() } + date::days{ current_time };
+
+  // Get reporting window
+  auto smc_reporting_start_day = config_->smc_reporting_start_day();
+  auto smc_reporting_end_day   = config_->smc_reporting_end_day();
+
+  // Compare as sys_days (safe for <=, >= comparisons)
+  date::sys_days start_sd = date::sys_days{smc_reporting_start_day};
+  date::sys_days end_sd   = date::sys_days{smc_reporting_end_day};
+
+  // Call reporter only if in range
+  if (cur_sd >= start_sd && cur_sd <= end_sd) {
+      for (auto* reporter : reporters_) {
+          if (auto* smc_reporter = dynamic_cast<SMCReporter*>(reporter)) {
+              smc_reporter->custom_report();
+          }
+      }
+  }
+
+  // END added for SMC custom report
+
 }
 
 // this will be called by scheduler at the beginning of first day of the month

--- a/src/Population/Person.cpp
+++ b/src/Population/Person.cpp
@@ -822,9 +822,47 @@ double Person::prob_present_at_mda() {
   return prob_present_at_mda_by_age_[i];
 }
 
+
+//added for SMC
+
+void Person::generate_prob_present_at_smc_by_location() {
+  if (prob_present_at_smc_by_location().empty()) {
+
+    // loop over district instead of pixel
+    //for (std::size_t loc = 0; loc < Model::CONFIG->number_of_locations(); loc++) {
+    for (std::size_t i = 0;
+         i < Model::CONFIG->mean_prob_individual_present_at_smc().size(); i++) {
+
+      auto alpha = Model::CONFIG->prob_individual_present_at_smc_distribution()[i].alpha;
+      auto beta = Model::CONFIG->prob_individual_present_at_smc_distribution()[i].beta;
+      auto value = Model::RANDOM->random_beta(alpha, beta);
+      prob_present_at_smc_by_location_.push_back(value);
+    }
+  }
+}
+
+double Person::prob_present_at_smc() {
+  auto district = SpatialData::get_instance().get_admin_unit(
+      "district", location_);
+  auto smc_districts = Model::CONFIG->smc_districts();
+
+  auto it = std::find(smc_districts.begin(), smc_districts.end(), district);
+  if (it != smc_districts.end()) {
+    std::size_t index = std::distance(smc_districts.begin(), it);
+    return prob_present_at_smc_by_location_[index];
+  }
+  else{
+    return 0.0; // Not in SMC district
+  }
+  
+  
+}
+
 bool Person::has_effective_drug_in_blood() const {
   for (const auto &kv_drug : *drugs_in_blood_->drugs()) {
-    if (kv_drug.second->last_update_value() > 0.5) return true;
+    // if (kv_drug.second->last_update_value() > 0.5) return true; //  threshold before SMC 
+    if (kv_drug.second->last_update_value() > Model::CONFIG->has_effective_drug_in_blood_threshold()) return true;
+
   }
   return false;
 }

--- a/src/Population/Person.h
+++ b/src/Population/Person.h
@@ -122,6 +122,10 @@ public:
 
   PROPERTY_REF(std::vector<double>, prob_present_at_mda_by_age)
 
+  // added for SMC
+  PROPERTY_REF(std::vector<double>, prob_present_at_smc_by_location)
+  PROPERTY_REF(bool, tracked_for_smc)
+
 #ifdef ENABLE_TRAVEL_TRACKING
   PROPERTY_REF(int, day_that_last_trip_was_initiated)
   PROPERTY_REF(int, day_that_last_trip_outside_district_was_initiated)
@@ -277,6 +281,11 @@ public:
   void generate_prob_present_at_mda_by_age();
 
   double prob_present_at_mda();
+
+  // added for SMC
+  void generate_prob_present_at_smc_by_location();
+
+  double prob_present_at_smc();
 
   bool has_effective_drug_in_blood() const;
 

--- a/src/Population/Population.cpp
+++ b/src/Population/Population.cpp
@@ -328,6 +328,9 @@ void Population::generate_individual(int location, int age_class) {
   p->schedule_update_every_K_days_event(time);
   p->generate_prob_present_at_mda_by_age();
 
+  // added for SMC
+  p->generate_prob_present_at_smc_by_location();
+
   add_person(p);
 }
 
@@ -528,6 +531,9 @@ void Population::give_1_birth(const int &location) {
 
   p->schedule_update_every_K_days_event(Model::CONFIG->update_frequency());
   p->generate_prob_present_at_mda_by_age();
+
+  // added for SMC
+  p->generate_prob_present_at_smc_by_location();
 
   add_person(p);
 }

--- a/src/Population/Population.h
+++ b/src/Population/Population.h
@@ -41,6 +41,9 @@ class Population : public Dispatcher {
   // Population size currently in the location
   PROPERTY_REF(IntVector, popsize_by_location)
 
+  // id of people being tracked for SMC analysis // added for SMC
+  PROPERTY_REF(IntVector, smc_tracked_person_ids) 
+
 private:
   // Generate the individual at the given location
   void generate_individual(int location, int age_class);

--- a/src/Reporters/Reporter.cpp
+++ b/src/Reporters/Reporter.cpp
@@ -19,6 +19,8 @@
 #include "Specialist/SeasonalImmunity.h"
 #include "easylogging++.h"
 
+#include "Reporters/SMCReporter.h" //added for SMC
+
 #ifdef ENABLE_TRAVEL_TRACKING
 #include "Reporters/TravelTrackingReporter.h"
 #endif
@@ -31,6 +33,7 @@ std::map<std::string, Reporter::ReportType> Reporter::ReportTypeMap{
     {"CellularReporter", CELLULAR_REPORTER},
     {"SeasonalImmunity", SEASONAL_IMMUNITY},
     {"AgeBand", AGE_BAND_REPORTER},
+    {"SMCReporter", SMC_REPORTER}, //added for SMC
     {"SQLiteMonthlyReporter", SQLITE_MONTHLY_REPORTER},
 #ifdef ENABLE_TRAVEL_TRACKING
     {"TravelTrackingReporter", TRAVEL_TRACKING_REPORTER},
@@ -53,6 +56,8 @@ Reporter* Reporter::MakeReport(ReportType report_type) {
       return new SeasonalImmunity();
     case AGE_BAND_REPORTER:
       return new AgeBandReporter();
+    case SMC_REPORTER: //added for SMC
+      return new SMCReporter();
     case SQLITE_MONTHLY_REPORTER:{
       auto cell_level_reporting = Model::CONFIG->cell_level_reporting();
       return new SQLiteMonthlyReporter(cell_level_reporting);

--- a/src/Reporters/Reporter.h
+++ b/src/Reporters/Reporter.h
@@ -59,6 +59,7 @@ public:
     SQLITE_MONTHLY_REPORTER,
 
     TRAVEL_TRACKING_REPORTER,
+    SMC_REPORTER, //added for SMC
     // Null reporter used when the model needs to be initialized for access to
     // functionality
     NULL_REPORTER

--- a/src/Reporters/SMCReporter.cpp
+++ b/src/Reporters/SMCReporter.cpp
@@ -1,0 +1,376 @@
+//#ifdef ENABLE_SMC
+#include "SMCReporter.h"
+#include <fmt/core.h>
+#include "Model.h"
+#include "Population/Properties/PersonIndexAll.h"
+#include "Population/Person.h"
+#include "Population/Population.h"
+#include "Population/DrugsInBlood.h"
+#include "Therapies/Drug.h"
+#include "Core/Config/Config.h"
+
+#include <algorithm>   
+#include <random>  
+#include <vector>
+#include <unordered_set>
+#include "Events/Population/SMCEvent.h"
+
+SMCReporter::SMCReporter() = default;
+SMCReporter::~SMCReporter() = default;
+
+void SMCReporter::initialize(int job_number,
+                                        const std::string &path) {
+  output_file.open(fmt::format("{}smc_tracking_{}.txt", path, job_number));
+}
+
+void SMCReporter::before_run() {}
+
+void SMCReporter::begin_time_step() {}
+
+void SMCReporter::monthly_report() {
+  /*
+  auto* all_person_index =Model::POPULATION->get_person_index<PersonIndexAll>();
+
+  for (auto* person : all_person_index->vPerson()) {
+
+    //if (person->host_state() == Person::DEAD) { continue; } // previous (possibly incorrect code)
+    if (person->host_state() == Person::HostStates::DEAD) { continue; }
+    // if (person->age_in_floating() > 10) { continue; }
+    
+
+    //output_file << fmt::format("Date: {}, Person ID: {}, Location ID: {}, Age: {:.2f}, SP: {}\n", date::format("%Y\t%m\t%d", Model::SCHEDULER->calendar_date), person->get_uid(), person->location(), person->age_in_floating(), person->drugs_in_blood()->is_drug_in_blood(2)); 
+
+
+
+    for (const auto &kv_drug : *person->drugs_in_blood()->drugs()) {
+      //output_file << fmt::format("Date: {}, Person ID: {}, Location ID: {}, Age: {:.2f}, Drug ID: {}, Last update value: {}\n", date::format("%Y\t%m\t%d", Model::SCHEDULER->calendar_date), person->get_uid(), person->location(), person->age_in_floating(), kv_drug.first, kv_drug.second->last_update_value());
+      //std::cout<<kv_drug.first<<std::endl;
+      output_file << fmt::format("Date: {}, Person ID: {}, Location ID: {}, Age: {:.2f}, Drug ID: {}, present: {}\n", date::format("%Y\t%m\t%d", Model::SCHEDULER->calendar_date), person->get_uid(), person->location(), person->age_in_floating(), kv_drug.first, (person->drugs_in_blood()->is_drug_in_blood(kv_drug.first) ? "true" : "false") );
+
+      }
+    }
+    */
+}
+
+int SMCReporter::get_first_smc_month() const {
+    int first = 13; 
+
+    for (const auto& day_events : Model::SCHEDULER->population_events_list_) {
+        for (Event* ev : day_events) {
+            auto* smc = dynamic_cast<SMCEvent*>(ev);
+            if (!smc) continue;
+            first = std::min(first, smc->smc_month);
+        }
+    }
+
+    return first == 13 ? -1 : first;
+}
+
+void SMCReporter::custom_report(){
+
+  // Get all person references
+  auto* all_person_index = Model::POPULATION->get_person_index<PersonIndexAll>();
+
+  //Ensure the tracked list is initialized once if refresh easch interval is set to false
+  if ((Model::CONFIG->smc_refresh_samples_each_interval()) || Model::POPULATION->smc_tracked_person_ids().empty()) {
+    int num_people_tracked = Model::CONFIG->smc_reporting_number_of_people_tracked();
+
+    
+    double min_age_years = 3.0/12.0;  // retrieve from config later
+    double max_age_years = 60.0/12.0; // 5 years actual upper limit
+
+    int smc_month = get_first_smc_month();
+
+    // If no SMC months found, return without adjusting max age
+    if (smc_month != -1) {
+
+        unsigned current_month = unsigned(date::year_month_day(Model::SCHEDULER->calendar_date).month());
+
+        int month_gap = smc_month - current_month;
+        if (month_gap < 0) month_gap += 12; // When SMC starts earlier in the year than tracking date, works if we are operating inside a 12-month cycle
+
+        // Shrink by an extra 1 month to account for cases when SMC is given near end of the month
+        month_gap += 1;
+
+        // Adjust maximum allowed age so selected kids remain <5 at SMC
+        max_age_years -= (month_gap / 12.0);
+    }
+
+    // std::cout << "SMCReporter: Selecting " << num_people_tracked
+    //           << " people to track, age range: "
+    //           << min_age_years << " to " << max_age_years
+    //           << " years." << std::endl;
+
+
+
+    
+
+    if (Model::CONFIG->smc_reporting_track_per_district()) {
+
+      // number of people tracked is per district
+
+      //collect preople by district
+
+      std::unordered_map<int, std::vector<int>> district_to_ids;
+      for (auto *person : all_person_index->vPerson()) {
+        double age_in_years = person->age_in_floating();
+        if (age_in_years < min_age_years || age_in_years >= max_age_years) continue;
+        int district_id = SpatialData::get_instance().get_admin_unit("district", person->location());
+        district_to_ids[district_id].push_back(person->get_uid());
+      }
+
+      std::random_device rd;
+      std::mt19937 gen(rd());
+
+      auto& tracked_ids = Model::POPULATION->smc_tracked_person_ids();
+
+      // Now, for each district, shuffle and pick people
+      for (const auto& kv : district_to_ids) {
+        auto shuffled_ids = kv.second;
+        std::shuffle(shuffled_ids.begin(), shuffled_ids.end(), gen);
+
+        int n = std::min(num_people_tracked, static_cast<int>(shuffled_ids.size()));
+        tracked_ids.insert(tracked_ids.end(), shuffled_ids.begin(), shuffled_ids.begin() + n);
+      }
+
+    }
+
+
+    else{
+
+    // number of people tracked is countrywide
+
+    // Gather all person UIDs
+    std::vector<int> all_ids;
+    all_ids.reserve(all_person_index->vPerson().size());
+    for (auto* person : all_person_index->vPerson()) {
+        double age_in_years = person->age_in_floating();
+        if (age_in_years >= min_age_years && age_in_years < max_age_years) {
+                 all_ids.push_back(person->get_uid());
+        }
+
+    }
+
+    // Shuffle randomly
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::shuffle(all_ids.begin(), all_ids.end(), gen);
+
+    // Pick the first N people
+    int n = std::min(num_people_tracked, static_cast<int>(all_ids.size()));
+
+    
+    auto& tracked_ids = Model::POPULATION->smc_tracked_person_ids();
+    tracked_ids.assign(all_ids.begin(), all_ids.begin() + n);
+    }
+  }
+
+  /*
+  // comment after getting number of children for burkina faso
+  int num_people_tracked = Model::CONFIG->smc_reporting_number_of_people_tracked();
+
+    
+  double min_age_years = 0; // hardcoded , retrieve from configuration
+  double max_age_years = 5;
+
+            
+
+  // Gather all person UIDs
+  std::vector<int> all_ids;
+  all_ids.reserve(all_person_index->vPerson().size());
+  for (auto* person : all_person_index->vPerson()) {
+    double age_in_years = person->age_in_floating();
+    if (age_in_years >= min_age_years && age_in_years <= max_age_years) {
+          all_ids.push_back(person->get_uid());
+       }
+  
+  }
+
+
+  // Printing population under 5 at the end of each month
+    auto current_date = Model::SCHEDULER->calendar_date;
+
+    // Compute the last day of this month
+    auto ymd = date::year_month_day{current_date};
+    auto next_month = date::year_month{ymd.year(), ymd.month()} + date::months{1};
+    auto first_day_next_month = date::sys_days{next_month / date::day{1}};
+    auto last_day_this_month = first_day_next_month - date::days{1};
+
+    // Check if current date equals the last day of the month
+    if (current_date == last_day_this_month) {
+        std::cout << fmt::format(
+            "Total number of people with age under 5: {} in {}",
+            all_ids.size(),
+            date::format("%Y-%m", current_date)
+        ) << std::endl;
+    }
+}
+
+ // END comment after getting number of children for burkina faso
+ */
+
+  // uncomment below for actual function
+
+  
+
+
+  // Now prepare a fast lookup set (used in both cases)
+  const auto& tracked_ids_vec = Model::POPULATION->smc_tracked_person_ids();
+  std::unordered_set<int> tracked_ids(tracked_ids_vec.begin(), tracked_ids_vec.end());
+
+
+  
+  for (auto* person : all_person_index->vPerson()) {
+
+    //if (person->host_state() == Person::DEAD) { continue; } // previous (possibly incorrect code)
+    //if (person->host_state() == Person::HostStates::DEAD) { continue; }
+    // if (person->age_in_floating() > 10) { continue; }
+    
+
+    //output_file << fmt::format("Date: {}, Person ID: {}, Location ID: {}, Age: {:.2f}, SP: {}\n", date::format("%Y\t%m\t%d", Model::SCHEDULER->calendar_date), person->get_uid(), person->location(), person->age_in_floating(), person->drugs_in_blood()->is_drug_in_blood(2)); 
+
+
+    // all present drugs
+    
+    //for (const auto &kv_drug : *person->drugs_in_blood()->drugs()) {
+      ////output_file << fmt::format("Date: {}, Person ID: {}, Location ID: {}, Age: {:.2f}, Drug ID: {}, Last update value: {}\n", date::format("%Y\t%m\t%d", Model::SCHEDULER->calendar_date), person->get_uid(), person->location(), person->age_in_floating(), kv_drug.first, kv_drug.second->last_update_value());
+      ////std::cout<<kv_drug.first<<std::endl;
+    //  output_file << fmt::format("Date: {}, Person ID: {}, Location ID: {}, Age: {:.2f}, Drug ID: {}, present: {}\n", date::format("%Y\t%m\t%d", Model::SCHEDULER->calendar_date), person->get_uid(), person->location(), person->age_in_floating(), kv_drug.first, (person->drugs_in_blood()->is_drug_in_blood(kv_drug.first) ? "true" : "false") );
+
+    //}
+    
+
+   // only drug 2 (SP) or drug 1 (AQ)
+
+   //uncomment below to track all people
+
+   
+
+    //if (person->drugs_in_blood()->is_drug_in_blood(2)) {
+    //  output_file << fmt::format("Date: {}, Person ID: {}, Location ID: {}, Age: {:.2f}, Drug ID: {}, Last update value: {}\n", date::format("%Y\t%m\t%d", Model::SCHEDULER->calendar_date), person->get_uid(), person->location(), person->age_in_floating(), 2, person->drugs_in_blood()->get_drug(2)->last_update_value());
+    //}
+
+    //if (person->drugs_in_blood()->is_drug_in_blood(1)) {
+    //  output_file << fmt::format("Date: {}, Person ID: {}, Location ID: {}, Age: {:.2f}, Drug ID: {}, Last update value: {}\n", date::format("%Y\t%m\t%d", Model::SCHEDULER->calendar_date), person->get_uid(), person->location(), person->age_in_floating(), 1, person->drugs_in_blood()->get_drug(1)->last_update_value());
+    //}
+
+
+    // end track all people
+
+  
+
+    // keeping track of infection and concentration of drug in bloof of people selected
+
+    if (tracked_ids.count(person->get_uid()) > 0) {
+        // Get infection state as string
+        std::string state_str;
+        switch (person->host_state()) {
+            case Person::HostStates::SUSCEPTIBLE: state_str = "SUSCEPTIBLE"; break;
+            case Person::HostStates::EXPOSED: state_str = "EXPOSED"; break;
+            case Person::HostStates::ASYMPTOMATIC: state_str = "ASYMPTOMATIC"; break;
+            case Person::HostStates::CLINICAL: state_str = "CLINICAL"; break;
+            case Person::HostStates::DEAD: state_str = "DEAD"; break;
+            default: state_str = "UNKNOWN"; break;
+        }
+
+        
+
+        // get parasite density (reference : IndividaulsFileReporter)
+        double p_density;
+        if (person->all_clonal_parasite_populations()->parasites()->size() >= 1) {
+        p_density = person->all_clonal_parasite_populations()
+                        ->parasites()
+                        ->at(0)
+                        ->last_update_log10_parasite_density();
+      } else {
+        p_density =
+            Model::CONFIG->parasite_density_level().log_parasite_density_cured;
+      }
+
+      const std::size_t parasite_population_size = person->all_clonal_parasite_populations()->size();
+
+      // Build genotype summary for all clonal parasite populations
+      std::ostringstream genotype_stream;
+
+      for (std::size_t j = 0ul; j < parasite_population_size; j++) {
+          ClonalParasitePopulation* bp =
+              person->all_clonal_parasite_populations()->parasites()->at(j);
+
+          if (j > 0) {
+              genotype_stream << "; ";
+          }
+
+          genotype_stream << bp->genotype()->genotype_id()
+                          << "(" << bp->last_update_log10_parasite_density() << ")";
+
+          // std::cout << "Parasite population " << j
+          //           << ": Genotype ID = " << bp->genotype()->genotype_id()
+          //           << ", Log10 Parasite Density = " << bp->last_update_log10_parasite_density()
+          //           << std::endl;
+      }
+      // std::cout<<std::endl;
+
+      std::string genotypes = genotype_stream.str();
+
+
+        // Get drug concentrations if present
+        double drug0_val = 0.0, drug1_val = 0.0, drug2_val = 0.0, drug4_val = 0.0; // 0 => artemisinin, 1 => amodiaquine, 2 => SP, 4 => lumefantrine
+        if (person->drugs_in_blood()->is_drug_in_blood(1)) {
+            //std::cout<<"Person " << person->get_uid() << " has drug 1 in blood with value " << person->drugs_in_blood()->get_drug(1)->last_update_value() << std::endl;
+            drug1_val = person->drugs_in_blood()->get_drug(1)->last_update_value();
+        }
+        if (person->drugs_in_blood()->is_drug_in_blood(2)) {
+            //std::cout<<"Person " << person->get_uid() << " has drug 2 in blood with value " << person->drugs_in_blood()->get_drug(2)->last_update_value() << std::endl;
+            drug2_val = person->drugs_in_blood()->get_drug(2)->last_update_value();
+        }
+
+        if (person->drugs_in_blood()->is_drug_in_blood(0)) {
+            //std::cout<<"Person " << person->get_uid() << " has drug 0 in blood with value " << person->drugs_in_blood()->get_drug(0)->last_update_value() << std::endl;
+            drug0_val = person->drugs_in_blood()->get_drug(0)->last_update_value();
+        }
+
+        if (person->drugs_in_blood()->is_drug_in_blood(4)) {
+            //std::cout<<"Person " << person->get_uid() << " has drug 4 in blood with value " << person->drugs_in_blood()->get_drug(4)->last_update_value() << std::endl;
+            drug4_val = person->drugs_in_blood()->get_drug(4)->last_update_value();
+        }
+
+        int district_id = SpatialData::get_instance().get_admin_unit("district", person->location());
+
+        // Write one combined log line
+        output_file << fmt::format(
+            "Date: {}, ID: {}, Loc: {}, Age: {:.2f}, State: {}, Drug0: {:.4f}, Drug1: {:.4f}, Drug2: {:.4f}, Drug3: {:.4f}, ParasiteDensity: {:.4f}, Genotypes: {}\n",
+            date::format("%Y-%m-%d", Model::SCHEDULER->calendar_date),
+            person->get_uid(),
+            district_id,
+            person->age_in_floating(),
+            state_str,
+            drug0_val,
+            drug1_val,
+            drug2_val,
+            drug4_val,
+            p_density,
+            genotypes
+        );
+
+
+
+    
+
+    }
+  }
+
+
+}
+
+
+
+void SMCReporter::after_run() {
+   output_file << fmt::format("SMC Reporter After Run");
+
+  // close the file
+  if (output_file.is_open()) { output_file.close(); }
+}
+
+
+
+//#endif  // ENABLE_SMC

--- a/src/Reporters/SMCReporter.h
+++ b/src/Reporters/SMCReporter.h
@@ -1,0 +1,31 @@
+#ifndef REPORTERS_SMCREPORTER_H
+#define REPORTERS_SMCREPORTER_H
+
+//#ifdef ENABLE_SMC
+
+#include <fstream>
+
+#include "Reporters/Reporter.h"
+
+class SMCReporter : public Reporter {
+  DELETE_COPY_AND_MOVE(SMCReporter)
+private:
+  std::ofstream output_file;
+
+public:
+  SMCReporter();
+  ~SMCReporter() override;
+
+  void initialize(int job_number, const std::string &path) override;
+  void before_run() override;
+  void after_run() override;
+  void begin_time_step() override;
+  void monthly_report() override;
+
+  int get_first_smc_month() const;
+
+  void custom_report();
+};
+
+//#endif  // ENABLE_SMC
+#endif  // REPORTERS_SMCREPORTER_H

--- a/src/Strategies/DistrictMftStrategy.cpp
+++ b/src/Strategies/DistrictMftStrategy.cpp
@@ -70,5 +70,6 @@ Therapy* DistrictMftStrategy::get_therapy(Person* person) {
   throw std::runtime_error("Scanned for therapy without finding a match: "
                            + this->name()
                            + ", district: " + std::to_string(district)
-                           + ", pr: " + std::to_string(pr));
+                           + ", pr: " + std::to_string(pr)
+                           + ", sum: " + std::to_string(sum));
 }


### PR DESCRIPTION
Implemented Features for Seasonal Malaria Chemoprevention (SMC), so that we can evaluate SMC deployment along with first-line therapies. A Daily Reporter is also implemented as a tool for SMC diagnostics.

Any SMC event must be configured under the events node in a configuration YAML file. Each entry should include the districts, the year range, and the months when SMC is given. The age range of SMC participants and coverage of SMC can also be defined.

  - name: SMC
    info:
    - districts: [40]
      year_range: [2015, 2025]
      months: [6, 7, 8, 9, 10]
      age_range: [3, 59]
      fraction_population_targeted: [0.552702]
      days_to_complete_all_treatments: 3
 
**Generic configuration for SMC must be specified as follows**

smc_therapy_id: 12 
has_effective_drug_in_blood_threshold: 0.725
coverage_adjustment: true #if true, the coverage will be decreased linearly from the provided coverage year to the start of SMC (10% each year and capped at 10% minimum) 

smc_districts: [1, 2, 3, 4, 5]
mean_prob_individual_present_at_smc: [1, 1, 1, 1, 1]
sd_prob_individual_present_at_smc: [0, 0, 0, 0, 0]

**Daily reporting allows us to track people over a duration. The required configurations are as follows**

smc_reporting_start_day: 2024/1/1
smc_reporting_end_day: 2025/12/31
smc_reporting_number_of_people_tracked: 1000 # number will be per district if the flag following is set to true
smc_reporting_track_per_district: false
smc_refresh_samples_each_interval: false # if true, new people are sampled each reporting interval, if false, same people are tracked throughout the reporting period

With the correct configuration, the simulation runs with SMC implemented on the defined dates.